### PR TITLE
Add Pending Task Protocol proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # community-protocols
 Cross-component coordination protocols
+
+## Proposals
+
+| Proposal        | Author         | Status |
+|-----------------|----------------|--------|
+| [Pending State] | Justin Fagnani | PR     |
+
+[Pending State]: [https://github.com/webcomponents/community-protocols/pull/1]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Check out the [Issues](https://github.com/webcomponents/community-protocols/issu
 
 | Proposal        | Author         | Status |
 |-----------------|----------------|--------|
-| [Pending State] | Justin Fagnani | Draft  |
+| [Pending Task] | Justin Fagnani | Draft  |
 
-[Pending State]: [https://github.com/webcomponents/community-protocols/pull/1]
+[Pending Task]: [https://github.com/webcomponents/community-protocols/pull/1]

--- a/proposals/pending-state.md
+++ b/proposals/pending-state.md
@@ -1,42 +1,47 @@
-# pending-state-protocol
+# pending-task-protocol
+
 An open protocol for interoperable asynchronous Web Components.
+
+Author: Justin Fagnani
 
 Document status: Draft
 
+Last update: 2020-10-28
+
 # Background
 
-There are a number of scenarios where a web component might depend on or perform some asynchronous work. Components may lazy-load parts of their implementation or content, perform I/O in response to user input, manage long-running computation, etc.
+There are a number of scenarios where a web component might depend on or perform some asynchronous task. Components may lazy-load parts of their implementation or content, perform I/O in response to user input, manage long-running computation, etc.
 
-It's often desirable to communicate the state of async work up the component tree to parent components so that they can display user affordances indicating whether the UI or content is pending some async operation.
+It's often desirable to communicate the state of async tasks up the component tree to parent components so that they can display user affordances indicating whether the UI or content is pending some async operation.
 
 Frameworks have the ability to invent custom APIs and patterns to handle this kind of cross-component communication. To enable the same with web components in a way that's interoperable between components from diffrent sources, and possibly implemented with different libraries, we need a protocol that components can implement without reliance on a common implementation.
 
 # Goals
 
-* Allow components to communicate that they have pending asynchonous work to ancestors in the DOM tree.
-* Allow components to know if there is pending asynchronous work in descendants in the DOM tree.
-* Allow components to intercept, modify, and block pending state notifications.
+* Allow components to communicate that they have pending asynchonous tasks to ancestors in the DOM tree.
+* Allow components to know if there are pending asynchronous tasks in descendants in the DOM tree.
+* Allow components to intercept, modify, and block pending task notifications.
 * Give guidance on the type of asynchronous work that should be notified.
 * Allow for some labelling or differentiation between types of asynchronous work.
 
 # Details
 
-## Asynchronous States
+## Asynchronous Task States
 
-There are four main states that an asynchronous operation can be in:
+There are four main states that an asynchronous task can be in:
 
 * Not-started
 * Started
 * Sucessfully completed
 * Failed
 
-## The `pending-state` event
+## The `pending-task` event
 
-Components with pending work indicate so by firing a composed, bubbling, `pending-state` Event, with a `promise` property:
+Components with pending tasks indicate so by firing a composed, bubbling, `pending-task` Event, with a `promise` property:
 
 TypeScript interface:
 ```ts
-interface PendingStateEvent extends Event {
+interface PendingTaskEvent extends Event {
   promise: Promise<void>;
 }
 ```
@@ -44,9 +49,9 @@ interface PendingStateEvent extends Event {
 Example:
 
 ```js
-class PendingStateEvent extends Event {
+class PendingTaskEvent extends Event {
   constructor(promise) {
-    super('pending-state', {bubbles: true, composed: true});
+    super('pending-task', {bubbles: true, composed: true});
     this.promise = promise;
   }
 }
@@ -56,7 +61,7 @@ class DoWorkElement extends HTMLElement {
   async doWork() { /* ... */ }
 
   startWork() {
-    this.dispatchEvent(new PendingStateEvent(this.doWork()));
+    this.dispatchEvent(new PendingTaskEvent(this.doWork()));
   }
 }
 
@@ -64,7 +69,7 @@ class DoWorkElement extends HTMLElement {
 class IndicateWorkElement extends HTMLElement {
   constructor() {
     super();
-    this.addEventListener('pending-state', async (e) => {
+    this.addEventListener('pending-task', async (e) => {
       this.showSpinner();
       await e.promise;
       this.hideSpinner();
@@ -73,12 +78,12 @@ class IndicateWorkElement extends HTMLElement {
 }
 ```
 
-The Promise must be resolved when the work is complete and rejected if the work fails. The value the Promise resolves to is unspecified.
+The Promise must be resolved when the task is complete and rejected if the task fails. The value the Promise resolves to is unspecified.
 
 Using an event with a Promise allows us to represent three of the four asynchronous states:
 
 * Not-started: not represented
-* Started: `pending-state` event fired
+* Started: `pending-task` event fired
 * Sucessfully completed: Promise resolved
 * Failed: Promise rejected
 
@@ -88,18 +93,14 @@ Using an event with a Promise allows us to represent three of the four asynchron
 
 Animations have multiple events: `animationstart` and `animationend`. Promises make it very easy to correlate the start of an operation with the end of that operation.
 
-## Event Name
-
-Is `pending-state` good? Should it be `pending-work`?
-
-## Types of Async Work
+## Types of Async Tasks
 
 There are some types of async work that we may not want to display UI affordances (like progress indicators) for. Async rendering used in order to yield to the browser's task queue for input hanlding and layout/paint for instance, should probably not trigger a progress indicator. Yet, code that measures style or layout may need to wait for rendering to complete.
 
 We could add a field to the event that indicates the type of work and standardize a small number of types, such as `loading` and `rendering`. An event to indicate async rendering starting and stopping has existing analogies with the `animationstart` and `animationend` events.
 
-We may also want to specifically reccomend against firing `pending-state` events for rendering work because of the pervasiveness of such async rendering with modern web component base classes like LitElement and Stencil.
+We may also want to specifically reccomend against firing `pending-task` events for rendering work because of the pervasiveness of such async rendering with modern web component base classes like LitElement and Stencil.
 
 ## Work Estimation
 
-Some use cases, like a progress bar that shows how much work is remaining, could benefit from estimating how much work is pending. The `pending-state` event could carry a numeric work estimate property so that containers can estimate the total amount of pending work and incremental progress.
+Some use cases, like a progress bar that shows how much work is remaining, could benefit from estimating how much work is pending. The `pending-task` event could carry a numeric work estimate property so that containers can estimate the total amount of pending work and incremental progress.

--- a/proposals/pending-state.md
+++ b/proposals/pending-state.md
@@ -1,0 +1,105 @@
+# pending-state-protocol
+An open protocol for interoperable asynchronous Web Components.
+
+Document status: Draft
+
+# Background
+
+There are a number of scenarios where a web component might depend on or perform some asynchronous work. Components may lazy-load parts of their implementation or content, perform I/O in response to user input, manage long-running computation, etc.
+
+It's often desirable to communicate the state of async work up the component tree to parent components so that they can display user affordances indicating whether the UI or content is pending some async operation.
+
+Frameworks have the ability to invent custom APIs and patterns to handle this kind of cross-component communication. To enable the same with web components in a way that's interoperable between components from diffrent sources, and possibly implemented with different libraries, we need a protocol that components can implement without reliance on a common implementation.
+
+# Goals
+
+* Allow components to communicate that they have pending asynchonous work to ancestors in the DOM tree.
+* Allow components to know if there is pending asynchronous work in descendants in the DOM tree.
+* Allow components to intercept, modify, and block pending state notifications.
+* Give guidance on the type of asynchronous work that should be notified.
+* Allow for some labelling or differentiation between types of asynchronous work.
+
+# Details
+
+## Asynchronous States
+
+There are four main states that an asynchronous operation can be in:
+
+* Not-started
+* Started
+* Sucessfully completed
+* Failed
+
+## The `pending-state` event
+
+Components with pending work indicate so by firing a composed, bubbling, `pending-state` Event, with a `promise` property:
+
+TypeScript interface:
+```ts
+interface PendingStateEvent extends Event {
+  promise: Promise<void>;
+}
+```
+
+Example:
+
+```js
+class PendingStateEvent extends Event {
+  constructor(promise) {
+    super('pending-state', {bubbles: true, composed: true});
+    this.promise = promise;
+  }
+}
+
+// Inside a component definition:
+class DoWorkElement extends HTMLElement {
+  async doWork() { /* ... */ }
+
+  startWork() {
+    this.dispatchEvent(new PendingStateEvent(this.doWork()));
+  }
+}
+
+// Inside a container component:
+class IndicateWorkElement extends HTMLElement {
+  constructor() {
+    super();
+    this.addEventListener('pending-state', async (e) => {
+      this.showSpinner();
+      await e.promise;
+      this.hideSpinner();
+    });
+  }
+}
+```
+
+The Promise must be resolved when the work is complete and rejected if the work fails. The value the Promise resolves to is unspecified.
+
+Using an event with a Promise allows us to represent three of the four asynchronous states:
+
+* Not-started: not represented
+* Started: `pending-state` event fired
+* Sucessfully completed: Promise resolved
+* Failed: Promise rejected
+
+# Open Questions
+
+## Should the event carry a Promise or should there be two events?
+
+Animations have multiple events: `animationstart` and `animationend`. Promises make it very easy to correlate the start of an operation with the end of that operation.
+
+## Event Name
+
+Is `pending-state` good? Should it be `pending-work`?
+
+## Types of Async Work
+
+There are some types of async work that we may not want to display UI affordances (like progress indicators) for. Async rendering used in order to yield to the browser's task queue for input hanlding and layout/paint for instance, should probably not trigger a progress indicator. Yet, code that measures style or layout may need to wait for rendering to complete.
+
+We could add a field to the event that indicates the type of work and standardize a small number of types, such as `loading` and `rendering`. An event to indicate async rendering starting and stopping has existing analogies with the `animationstart` and `animationend` events.
+
+We may also want to specifically reccomend against firing `pending-state` events for rendering work because of the pervasiveness of such async rendering with modern web component base classes like LitElement and Stencil.
+
+## Work Estimation
+
+Some use cases, like a progress bar that shows how much work is remaining, could benefit from estimating how much work is pending. The `pending-state` event could carry a numeric work estimate property so that containers can estimate the total amount of pending work and incremental progress.

--- a/proposals/pending-task.md
+++ b/proposals/pending-task.md
@@ -70,13 +70,19 @@ class DoWorkElement extends HTMLElement {
 
 // Inside a container component:
 class IndicateWorkElement extends HTMLElement {
+  #pendingTaskCount = 0;
+
   constructor() {
     super();
     this.addEventListener('pending-task', async (e) => {
       e.stopPropagation();
-      this.showSpinner();
+      if (++this.#pendingTaskCount === 1) {
+        this.showSpinner();
+      }
       await e.complete;
-      this.hideSpinner();
+      if (--this.#pendingTaskCount === 0) {
+        this.hideSpinner();
+      }
     });
   }
 }

--- a/proposals/pending-task.md
+++ b/proposals/pending-task.md
@@ -146,7 +146,7 @@ There are different types of async work. Whether this proposal should attempt to
 
 The argument against is that we simply do not yet know what categories there should be and how to definitively guide authors towards choosing the right type. It's also just additional complexity for component authors.
 
-An argument for is that there are some types of async work that we may not want to display UI affordances (like spinners) for. Async rendering used in order to yield to the browser's task queue for input hanlding and layout/paint for instance, should probably not trigger a progress indicator. Yet, code that measures style or layout may need to wait for rendering to complete, and so could utilize pending-state for that.
+An argument for is that there are some types of async work that we may not want to display UI affordances (like spinners) for. Async rendering used in order to yield to the browser's task queue for input hanlding and layout/paint for instance, should probably not trigger a progress indicator. Yet, code that measures style or layout may need to wait for rendering to complete, and so could potentially utilize pending-task for that.
 
 How can we allow UI affordances like spinners, but not to frequently create them during async rendering?
 

--- a/proposals/pending-task.md
+++ b/proposals/pending-task.md
@@ -118,13 +118,13 @@ this.addEventListener('pending-task', async (e) => {
 
 ## Default actions
 
-Some UI controls are able to show their own pending task indicators. One example is a form submit button with an embedded spinner. Such a controller may not want to show the loading indicator if a component above it in the tree is also. This can be accomplished with event default actions.
+Some UI controls are able to show their own pending task indicators. One example is a form submit button with an embedded spinner. Such a controller may not want to show the loading indicator if a component above it in the tree is also showing one. This can be accomplished with event default actions.
 
-Listeners cal call `e.preventDefault()` on the event:
+Listeners can call `e.preventDefault()` on the event:
 
 ```ts
 this.addEventListener('pending-task', async (e) => {
-  e.stopPropagation();
+  e.preventDefault();
   // show loading indicator
   await e.complete;
   // hide loading indicator


### PR DESCRIPTION
This adds a Pending Task Protocol proposal, which enables elements to communicate the status of outstanding async work up the DOM tree.

Closes #3 