### PR TITLE
[context] Fix type inconsistencies.

### DIFF
--- a/proposals/context.md
+++ b/proposals/context.md
@@ -96,11 +96,11 @@ Then values can be cast to this to create a typed context key:
 export const myContext = 'my-context' as Context<string, number>;
 ```
 
-The type of a Context can then be extracted with a utility type:
+The value type of a Context can then be extracted with a utility type:
 
 ```ts
-export type ContextType<Key extends Context<unknown, unknown>> =
-  Key extends Context<unknown, infer ValueType> ? ValueType : never;
+export type ContextType<T extends UnknownContext> =
+  T extends Context<infer _, infer V> ? V : never;
 ```
 
 Usage:


### PR DESCRIPTION
Fixes #58

As mentioned in https://github.com/webcomponents-cg/community-protocols/issues/58, I missed some type definitions when fixing #19. This fixes those.

I added one small rename for clarity, of `ContextEvent` -> `ContextRequestEvent`. This is more explicit and leaves room for other context related events, like maybe a `ContextProviderEvent` as a possible solution to https://github.com/webcomponents-cg/community-protocols/issues/25

The interface name _shouldn't_ be too significant here, since we aren't publishing these types, _but_:
1. People are copying the types from this README.
2. We _should_ publish the types here so that implementor can depend on them and get help from the TypeScript compiler to check that their implementation is at least type-compatible with the protocol. (we should also create a conformance test suite).

I copied these fixed types into `@lit/context` tests and discovered one place where the Lit types were incorrect, so they would be very useful for that sort of check.