### PR TITLE
[context] Propose a native API for the Context Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the [Issues](https://github.com/webcomponents/community-protocols/issu
 
 | Proposal       | Author           | Status     |
 |----------------|------------------|------------|
-| [Context]      | Benjamin Delarre | Candidate  |
+| [Context]      | Benjamin Delarre | Draft      |
 | [Defer Hydration] | Justin Fagnani | Proposal |
 | [Pending Task] | Justin Fagnani   | Draft      |
 | [Slottable Request] | Kevin Schaaf   | Proposal  |

--- a/proposals/context.md
+++ b/proposals/context.md
@@ -1,357 +1,872 @@
 # Context Protocol
 
-An open protocol for data passing between components.
+An open protocol for passing contextual data between components.
 
 Author: Benjamin Delarre
 
 Document status: Candidate
 
-Last update: 2025-05-02
+Last update: 2026-08-13
 
 # Background
 
-There are a number of scenarios where a web component might require data that is provided from outside itself. While components can specify properties and attributes to receive that data imperatively or declaratively, it is often the case that the data may be owned somewhere further up the DOM tree.
-
-One approach to passing this data down to components is commonly referred to as *prop drilling*, whereby components pass properties all the way down through the hierarchy, passing from component to component until it is consumed at its destination. This is generally considered undesirable as it often requires intermediate components in the tree to have knowledge of the data necessary in its descendents.
-
-Frameworks and libraries often provide mechanisms for this, these can range from the simple Context implementation available in React, to more complex Dependency Injection frameworks. Web components need a similar protocol in order to solve this problem.
+Web components often need data owned by an ancestor, such as a theme, locale, logger, or state store.
+Passing that data through every intermediate component couples those components to data they do not otherwise use.
+Frameworks commonly solve this with context or dependency-injection APIs, but components built with different libraries need a shared browser API.
 
 # Goals
 
-- Allow elements in the DOM to retrieve data based on their contextual position in the DOM
-- Alleviate the problem of *prop drilling*
-- Simple API that is easily implemented in any framework / library
-- Synchronous protocol, while supporting asynchronous patterns
-- Support single or multiple delivery of context values
+- Resolve context from the nearest matching provider on an element's composed event path.
+- Avoid passing contextual data through unrelated intermediate components.
+- Provide synchronous discovery when a provider is already available.
+- Let one-time requests wait for a later provider.
+- Support subscriptions, provider replacement, and explicit cancellation.
+- Give frameworks and plain custom elements the same API.
 
-# Non-Goals
+# Non-goals
 
-**Context API !== Dependency Injection Framework**
+The Context Protocol is not a dependency-injection framework.
+It does not define constructor, factory, or property injection.
+A dependency-injection system may use this protocol to locate dependencies, but those higher-level patterns are outside its scope.
 
-The Context API does not intend to cover all cases and forms of Dependency Injection. It does not specify constructor, factory or property injection patterns. Its only goal is to formalize the pattern of sharing data across the hierarchy in the DOM, specifically avoiding *prop drilling* type scenarios. Dependency Injection patterns could be implemented using this protocol, but this is not the goal and should remain explicitly outside the scope of Context API for simplicity.
+The Context Protocol is also not a state-management system.
+A component may use it to obtain a state store, but the protocol does not define how state is stored, updated, or observed.
 
-**Context API is not a state management alternative**
+# API
 
-State management libraries often need to solve some similar problems that the Context API helps to solve. An element deep in the DOM tree may need access to some state, and may need to respond to that state being changed.
+The protocol consists of two event interfaces and two methods on `Element`:
 
-While state management could be built using the Context API, it is not a primary goal of the Context API to solve this problem. It is, however, appropriate for state management libraries to use the Context API to resolve state stores and other associated dependencies from deep within the DOM hierarchy; e.g. a component could request a Redux state store via Context.
+- `ContextRequestEvent` discovers the nearest provider synchronously.
+- `ContextProviderEvent` announces that a provider's availability has changed.
+- `requestContext()` obtains one value, waiting for a later provider if needed.
+- `subscribeContext()` receives values from the nearest provider until its signal aborts.
 
-# Overview
+The element that dispatches a request is the consumer.
+A provider is an ancestor element whose request listener responds with a value for the requested context key.
 
-At a high level, the Context API is an event-based protocol that components can use to retrieve data from any location in the DOM:
-
-- A component requiring some data fires a `context-request` event.
-- The event carries a `context` value that denotes the data requested, and a `callback` which will receive the data.
-- Providers can attach event listeners for `context-request` events to handle them and provide the requested data.
-- Once a provider satisfies a request it calls `stopImmediatePropagation()` on the event.
-
-# Details
-
-## The `context-request` event
-
-Components which wish to receive some data from their ancestors should initiate the request by firing a composed, bubbling, `context-request` Event, with a `callback` property.
-
-TypeScript interface:
-
-```typescript
-interface ContextRequestEvent<T extends Context<unknown, unknown>> extends Event {
-  /**
-   * The name of the context that is requested
-   */
-  readonly context: T;
-  /**
-   * A boolean indicating if the context should be provided more than once.
-   */
-  readonly subscribe?: boolean;
-  /**
-   * A callback which a provider of this named callback should invoke.
-   */
-  readonly callback: ContextCallback<T>;
-}
-```
-
-A full TypeScript definition for this event and its associated types can be found in the [Definitions](#definitions) section at the end of this document.
-
-## Context objects
-
-`ContextRequestEvent`s carry a `context` value that is used to identify specific contexts. This value may sometimes be referred to as the "context key", and can be of any type.
-
-### Context equality
-
-Matching contexts between a provider and consumer is done with strict equality (`===`). This means that a context can be made guaranteed unique by using a key value that's unique under strict equality, like a unique Symbol (not using `Symbol.for()`) or an object. A context can be intentionally made to match other contexts by using a key that's not unique under strict equality like a string or `Symbol.for()`.
-
-### Context types
-
-In TypeScript it's possible to cast values to an interface that carries additional type information. This is useful for contexts to convey the type of the value that the context provides.
-
-To be interoperable, implementations should cast context keys to a type with the `__context__` key:
-
-```ts
-export type Context<KeyType, ValueType> = KeyType & {__context__: ValueType};
-```
-
-Then values can be cast to this to create a typed context key:
-
-```ts
-export const myContext = 'my-context' as Context<string, number>;
-```
-
-The value type of a Context can then be extracted with a utility type:
-
-```ts
-export type ContextType<T extends UnknownContext> =
-  T extends Context<infer _, infer V> ? V : never;
-```
-
-Usage:
-```ts
-// MyContextType = number
-type MyContextType = ContextType<typeof myContext>;
-```
-
-It is recommended that TypeScript-based implementations provide both `Context` and `ContextType` types.
-
-### `createContext` functions
-
-It is recommended that TypeScript implementations provide a `createContext()` function which is used to create a `Context`. This function can just cast to a `Context`:
-
-```ts
-export const createContext = <ValueType>(key: unknown) =>
-    key as Context<typeof key, ValueType>;
-```
-
-## Context Providers
-
-A context provider will satisfy a `context-request` event, passing the `callback` the requested data whenever the data changes. A provider will attach an event listener to the DOM tree to catch the event, and if it will be able to satisfy the request it _MUST_ call `stopImmediatePropagation` on the event.
-
-If the provider has data available to satisfy the request then it should immediately invoke the `callback` passing the data. If the event has a truthy `subscribe` property, then the provider can assume that the `callback` can be invoked multiple times, and may retain a reference to the callback to invoke as the data changes. If this is the case the provider should pass the second `unsubscribe` parameter to the callback when invoking it in order to allow the requester to disconnect itself from the providers notifications.
-
-The provider _MUST NOT_ retain a reference to the `callback` nor pass an `unsubscribe` callback if the `context-request` event's `subscribe` property is not truthy. Doing so may cause a memory leak as the consumer may not ever call the `unsubscribe` callback.
-
-To safeguard against memory leaks caused by non-compliant consumers that don't call the `unsubscribe` callback, it is recommended that the provider uses WeakRefs to reference subscription callbacks.
-
-The provider _SHOULD_ call `stopImmediatePropagation` before invoking the callback, or call the callback in a try/catch block, to ensure that an error thrown by the callback does not prevent immediate propagation from being stopped:
-
-```js
-this.addEventListener('context-request', event => {
-  event.stopImmediatePropagation();
-  // If the callback throws, propagation is already stopped
-  event.callback('some data');
-});
-```
-
-A provider does not necessarily have to be a Custom Element, but this may be a convenient mechanism.
-
-## Usage
-
-An element which wishes to receive some context and participate in the Context API should emit an event with the `context-request` type. It is suggested that an implementation of the `ContextRequestEvent` would be used something like this:
-
-```js
-// get a context from somewhere (this could be in any module)
-const coolThingContext = createContext('cool-thing');
-
-this.dispatchEvent(
-  new ContextRequestEvent(
-    coolThingContext, // the context we want to retrieve
-    (coolThing) => {
-      this.myCoolThing = coolThing; // do something with value
-    }
-  )
+```webidl
+callback ContextCallback = undefined (
+  any value,
+  optional VoidFunction unsubscribe
 );
+
+callback ContextConsumerCallback = undefined (any value);
+
+[Exposed=Window]
+interface ContextRequestEvent : Event {
+  constructor(DOMString type, ContextRequestEventInit eventInitDict);
+
+  readonly attribute any context;
+  readonly attribute Element? contextTarget;
+  readonly attribute ContextCallback _callback;
+  readonly attribute boolean subscribe;
+  readonly attribute AbortSignal? signal;
+
+  undefined respond(any value, optional VoidFunction unsubscribe);
+};
+
+dictionary ContextRequestEventInit : EventInit {
+  required any context;
+  required ContextConsumerCallback _callback;
+  boolean subscribe = false;
+  AbortSignal? signal = null;
+};
+
+[Exposed=Window]
+interface ContextProviderEvent : Event {
+  constructor(DOMString type, ContextProviderEventInit eventInitDict);
+
+  readonly attribute any context;
+  readonly attribute Element? contextTarget;
+};
+
+dictionary ContextProviderEventInit : EventInit {
+  required any context;
+};
+
+partial interface Element {
+  Promise<any> requestContext(
+    any context,
+    optional ContextRequestOptions options = {}
+  );
+
+  undefined subscribeContext(
+    any context,
+    ContextConsumerCallback callback,
+    ContextSubscriptionOptions options
+  );
+};
+
+dictionary ContextRequestOptions {
+  AbortSignal signal;
+};
+
+dictionary ContextSubscriptionOptions {
+  required AbortSignal signal;
+};
 ```
 
-If a provider listening for this event can provide the requested context it will invoke the callback passed in the payload of the event. The element can then do whatever it wishes with this value.
+The event constructors accept the usual `EventInit` members and preserve the values supplied by the author.
+Only the qualifying context events defined below participate in the protocol.
+If `ContextRequestEventInit.subscribe` is true and its `signal` is null, the `ContextRequestEvent` constructor throws a `TypeError`.
 
-It may also be the case that a provider can retain a reference to this callback, and can then invoke the callback multiple times. In this case providers should pass an unsubscribe function as a second argument to the callback to allow consumers to inform the provider that it should no longer update the element, and should dispose of the callback.
+The `callback` constructor option is the consumer callback.
+The `callback` attribute returns a user-agent-created delivery callback for providers.
+A provider retains the delivery callback to send subscription updates.
+The delivery callback validates the current provider before forwarding a value to the consumer callback.
+It invokes the consumer callback with the request's `contextTarget` as the callback `this` value.
 
-An element may also provide a `subscribe` boolean on the event detail to indicate that it is interested in receiving updates to the value.
+The delivery callback has a stable identity for the lifetime of the event.
+Fresh events that the user agent creates for an existing operation use that operation's delivery callback.
 
-Consumers should be aware that given that there is a loose coupling between implementations with this protocol that they may need to implement the `callback` handling defensively. An example of a defensive consumer that only wants a value once is provided below:
+# Context keys
+
+A context key identifies the requested value.
+Keys are compared using strict equality (`===`).
+A key can be any JavaScript value other than `NaN`.
+Because `NaN` does not strictly equal itself, it could never match a provider.
+
+A unique symbol or object creates a context that can only be shared by code with access to that value.
+A string or `Symbol.for()` key can intentionally identify the same context across independently loaded modules.
+
+Constructing either context event with `NaN` as its context throws a `TypeError`.
+Calling `requestContext()` with `NaN` returns a promise rejected with a `TypeError`.
+Calling `subscribeContext()` with `NaN` throws a `TypeError`.
+
+# Qualifying context events
+
+A qualifying context request is a `ContextRequestEvent` that:
+
+- has a `type` of exactly `context-request`;
+- has `bubbles` and `composed` set to true;
+- has `cancelable` set to false; and
+- is dispatched from an `Element`.
+
+A qualifying provider announcement is a `ContextProviderEvent` that has a `type` of exactly `context-provider`, has `bubbles` and `composed` set to true, has `cancelable` set to false, and is dispatched from an `Element`.
+
+A context event that does not meet these requirements is dispatched as an ordinary DOM event.
+It does not create, fulfill, or re-evaluate a context operation, and calling `respond()` on a non-qualifying request throws an `InvalidStateError` `DOMException`.
+
+This rule preserves the normal `Event` constructor shape while making protocol participation explicit.
+In particular, a `CustomEvent` named `context-request`, or a `ContextRequestEvent` constructed with `composed: false`, cannot accidentally enter the protocol.
+
+`contextTarget` is initially null.
+At the start of each dispatch, the user agent sets it to the `Element` on which `dispatchEvent()` was called, or to null for another kind of `EventTarget`.
+It is not retargeted across shadow boundaries or changed during dispatch.
+After dispatch, it remains set to the target of the most recent dispatch.
+For a request event, `contextTarget` identifies the consumer.
+For a provider announcement, it identifies the element whose provider availability changed.
+An event dispatched from a non-`Element` is not a qualifying context event.
+The first qualifying dispatch of a subscription request binds that event to its `contextTarget`.
+If `dispatchEvent()` is later called with that event on a different target, it throws an `InvalidStateError` `DOMException` before dispatch begins and leaves `contextTarget` unchanged.
+
+Each `ContextRequestEvent` has a responded flag.
+The user agent sets it to false at the start of each dispatch.
+`respond()` sets it to true for the rest of that dispatch.
+The flag is not exposed to authors.
+
+# Responding to a request
+
+The first matching provider encountered during the bubbling portion of DOM dispatch responds by calling `event.respond(value, unsubscribe)`.
+A provider must use a non-capturing request listener.
+A capturing listener cannot respond.
+At a shadow host, DOM can expose `eventPhase` as `AT_TARGET` while invoking a non-capturing listener during the bubbling portion of dispatch.
+That listener can respond; the `eventPhase` value alone does not determine response eligibility.
+
+A conforming provider must not install more than one active request listener on an element for the same context key.
+Otherwise, listener registration order would determine which listener responds.
+
+The `respond(value, unsubscribe)` method steps are:
+
+1. If this is not a qualifying context request whose current listener is being invoked during the bubbling portion of DOM dispatch, throw an `InvalidStateError` `DOMException`.
+2. If `currentTarget` is not an `Element`, is `contextTarget`, or another provider has already responded, throw an `InvalidStateError` `DOMException`.
+3. If `subscribe` is false and `unsubscribe` was supplied, throw a `TypeError`.
+4. If `subscribe` is true and `unsubscribe` was omitted, throw a `TypeError`.
+5. If `subscribe` is true and `signal` is aborted, throw an `InvalidStateError` `DOMException`.
+6. If the request is associated with a completed or terminated operation, throw an `InvalidStateError` `DOMException`.
+7. If the request is associated with an operation whose current provider is `currentTarget`, and `unsubscribe` is not that operation's current unsubscribe function, throw an `InvalidStateError` `DOMException`.
+8. Set the responded flag to true and call `stopImmediatePropagation()`.
+9. If the request is associated with a subscription operation, either confirm its current provider registration and set it to active or record `currentTarget` and `unsubscribe` as its prospective provider registration.
+   A one-time operation remains dispatching during this step.
+10. Except for the same-provider confirmation defined under provider re-evaluation, invoke the delivery callback synchronously with `value` and, for a subscription, `unsubscribe`.
+   The delivery callback validates the provider registration and invokes the consumer callback with `value`.
+11. If initial delivery to a prospective provider succeeds and the operation has not terminated, make the prospective registration current, set the operation to active, and clear the prospective registration.
+    If the operation had a previous provider, invoke its unsubscribe function and report any exception.
+
+If `respond()` throws before step 8, the user agent has not accepted an unsubscribe function.
+If the provider registered the delivery callback before calling `respond()`, it must remove that registration before propagating or reporting the exception.
+
+Once step 8 has run, the request remains responded to even if the callback throws.
+The user agent reports the exception, and it does not propagate to the provider or escape `dispatchEvent()`.
+This prevents a second provider from answering the same request.
+
+For a new subscription, the provider registers the delivery callback and its stable, idempotent unsubscribe function before calling `respond()`.
+If initial delivery throws, the user agent invokes that unsubscribe function, removes the new registration, terminates the subscription, and reports the exception.
+The exception does not escape `dispatchEvent()`.
+
+The user agent adds the subscription's abort algorithm before invoking the initial callback.
+If the signal aborts during initial delivery, termination wins: the new provider is unsubscribed and the operation does not become active.
+If this occurs during a transfer, both the old and new provider registrations are removed.
+
+Calling the delivery callback does not respond to a request.
+For initial delivery, `respond()` authorizes and invokes it as part of the atomic response steps.
+For a later subscription update, it invokes the consumer callback only when the supplied unsubscribe function is the operation's current provider unsubscribe function.
+In every other state, including before `respond()`, after completion or termination, or with a missing or stale unsubscribe function, it throws an `InvalidStateError` `DOMException` and does not invoke the consumer callback.
+
+During a transfer, the old provider remains active until initial delivery from the new provider succeeds.
+The user agent then invokes the previous provider's unsubscribe function.
+If initial delivery from the new provider throws, the new registration is removed and the old provider remains active.
+
+A provider's unsubscribe function must remove its registration before performing other cleanup, and later calls must have no effect.
+If provider cleanup throws, the user agent reports the exception and still completes the cancellation or transfer.
+
+The `context`, `subscribe`, and `signal` attributes return their corresponding `ContextRequestEventInit` values.
+The `callback` attribute returns the delivery callback associated with the consumer callback.
+
+The `context` attribute of `ContextProviderEvent` returns its corresponding `ContextProviderEventInit` value.
+
+# One-time requests
+
+## `requestContext()`
+
+`element.requestContext(context, options)` returns a new promise for a value from the nearest matching provider on the path that a composed event dispatched from `element` would follow.
+
+The `requestContext(context, options)` method steps are:
+
+1. If `context` is `NaN`, return a promise rejected with a `TypeError`.
+2. If `options.signal` is present and aborted, return a promise rejected with its abort reason.
+3. Create a new promise and a one-time context operation owned by `element`'s node document.
+   Its delivery callback completes the operation and resolves the promise with the supplied value.
+4. If a signal is present, add an abort algorithm that terminates the operation with the signal's abort reason.
+5. Append the operation to the document's context operations and dispatch it.
+6. Return the promise.
+
+If a provider responds, the operation's state becomes completed and the returned promise is resolved with the supplied value.
+Promise resolution follows the normal JavaScript rules, so a promise or thenable supplied as the context value is adopted.
+
+If no provider responds, the operation becomes pending.
+A later matching provider announcement causes the user agent to dispatch a fresh request from the element.
+The dispatched event itself is never retained or redispatched.
+
+If the signal aborts before the operation completes, the abort algorithm terminates the operation and rejects the promise with the signal's abort reason.
+Once a provider responds, aborting the signal has no effect on the supplied value or on asynchronous work represented by it.
+
+See [Requesting one value](#requesting-one-value) for an author-facing example.
+
+## Direct one-time events
+
+Authors can dispatch a qualifying `ContextRequestEvent` directly when they need synchronous delivery.
+
+If no provider responds before `dispatchEvent()` returns, a directly dispatched one-time request is a synchronous miss.
+The user agent does not retain it.
+Its `signal` does not cancel dispatch or prevent a response, because there is no retained operation to terminate.
+
+See [Requesting synchronously with a direct event](#requesting-synchronously-with-a-direct-event) for an author-facing example.
+
+# Subscriptions
+
+## `subscribeContext()`
+
+`element.subscribeContext(context, callback, {signal})` creates a subscription and immediately dispatches a fresh qualifying request from `element` with `subscribe` set to true.
+
+The `subscribeContext(context, callback, options)` method steps are:
+
+1. If `context` is `NaN`, throw a `TypeError`.
+2. If `signal` is aborted, return.
+3. Create a subscription operation owned by `element`'s node document.
+   Its delivery callback accepts a value and provider unsubscribe function.
+4. Add an abort algorithm to `signal` that terminates the operation.
+5. Append the operation to the document's context operations and dispatch it.
+
+When a provider responds, the user agent invokes `callback(value)` synchronously.
+It invokes the callback again when that provider supplies a new value or when the subscription transfers to a nearer provider.
+Aborting the signal removes a pending subscription or invokes the active provider's unsubscribe function.
+
+The user agent supplies the delivery callback to providers.
+It manages provider handoff and invokes the consumer callback.
+Authors using `subscribeContext()` therefore do not receive, compare, retain, or invoke provider unsubscribe functions.
+
+The delivery callback throws an `InvalidStateError` `DOMException` when invoked after the operation terminates or by a provider registration that is no longer current.
+If an active provider invokes it with an unsubscribe function other than that registration's stable function, it throws the same exception and does not deliver the value.
+
+If the consumer callback throws during initial delivery, the new subscription is terminated as described for `respond()`.
+If it throws during a later update, the user agent reports the exception, the exception does not propagate to the provider, and the subscription remains active.
+A provider must continue delivering the update to its other subscribers.
+
+See [Subscribing to a value](#subscribing-to-a-value) and [Providing a subscription](#providing-a-subscription) for author-facing examples.
+
+## Direct subscription events
+
+A directly constructed subscription request must supply a non-null signal.
+On its first qualifying dispatch, the user agent binds the event to the dispatching element.
+If the signal is already aborted, the event is dispatched without creating an operation, and `respond()` cannot accept it.
+Otherwise, before invoking any event listener, the user agent creates a subscription operation in the dispatching state for the event, adds an abort algorithm that terminates the operation, and appends the operation to the element's node document's context operations.
+
+The event remains associated with that operation after dispatch.
+Redispatching it from the same element reuses the operation, so it cannot create a duplicate subscription or replace the original signal.
+Before invoking a listener during a redispatch of a pending or active operation, the user agent records its state, current provider, and unsubscribe function and sets its state to dispatching.
+After an initial dispatch or redispatch, an operation terminated during dispatch remains terminated.
+Otherwise, a successful response leaves the operation active.
+If no provider responds and the operation was previously active, the user agent restores its active state, current provider, and unsubscribe function.
+If no provider responds and the operation was not previously active, the user agent sets it to pending.
+The user agent then applies any group transfer deferred during dispatch and resumes any provider re-evaluation pass suspended on the operation.
+A provider that responds while the operation remains pending or active can still deliver its current value again.
+Calling `dispatchEvent()` with the event on another target throws an `InvalidStateError` `DOMException` before dispatch begins.
+A separately constructed event represents a separate subscription, even if it was initialized with the same consumer callback.
+
+Binding a direct subscription to one target keeps its operation owner and callback `this` value stable.
+It also prevents one delivery callback from identifying operations for different elements or documents.
+
+If no provider responds, the operation remains pending until a provider responds or its signal aborts.
+When active, aborting its signal invokes its current provider's unsubscribe function.
+
+Providers invoke the retained delivery callback for each later value, passing the same unsubscribe function used in `respond()`.
+The user agent invokes the consumer callback with the value.
+If one consumer callback throws, the user agent reports that exception; the provider continues delivering to its other active subscriptions.
+
+See [Dispatching a direct subscription request](#dispatching-a-direct-subscription-request) for an author-facing example of same-target redispatch and cancellation.
+
+# Context operations and document ownership
+
+Each `Document` has an ordered set of context operations and a first-in-first-out queue of provider re-evaluation passes.
+A context operation is a user-agent-owned record with:
+
+- a kind: one-time request or subscription;
+- its target element and context key;
+- its consumer callback, delivery callback, and optional abort signal;
+- a state: dispatching, pending, active, completed, or terminated;
+- for a one-time request, its promise and resolving functions; and
+- for an active subscription, its current provider element and unsubscribe function; and
+- while establishing or transferring a subscription, its prospective provider element and unsubscribe function.
+
+The operation belongs to the target element's node document: the `Document` to which the target belongs.
+During a deferred adoption transfer, it remains owned by the old document until the group transfer steps run.
+Composed event paths do not cross document boundaries, so context discovery never reaches an embedding or embedded document, regardless of origin.
+
+An author-dispatched one-time event does not create an operation.
+A qualifying subscription event creates or reuses an operation as described under direct subscription events.
+The two `Element` methods create their operations before dispatch.
+
+The ordered set provides deterministic re-evaluation order.
+Operations are ordered by the time they are appended to their current document's set.
+Method-created operations are appended before their initial event dispatch, and a directly constructed subscription is appended before the first listener invocation of its initial dispatch.
+Re-dispatching an existing subscription does not move it in the order.
+
+## Dispatching a context operation
+
+To dispatch a context operation, the user agent:
+
+1. Returns if the operation is completed or terminated.
+2. If it has a signal and that signal is aborted, terminates the operation with the signal's abort reason and returns.
+3. Records the operation's state and, if it is active, its current provider and unsubscribe function.
+4. Sets its state to dispatching.
+5. Creates a fresh `ContextRequestEvent` with type `context-request`, the operation's context and consumer callback, its subscription and signal values, `bubbles` and `composed` set to true, and `cancelable` set to false.
+   It associates the event with the operation and its delivery callback.
+6. Dispatches the event from the operation's target element.
+7. Records whether a provider response completed successfully without terminating the operation or rolling back a prospective provider.
+8. If the operation is completed, terminated, or active, leaves its state unchanged.
+9. Otherwise, if the recorded state was active, restores its active state, provider, and unsubscribe function.
+10. Otherwise, sets the operation to pending.
+11. Applies any group transfer that was deferred during dispatch.
+12. Resumes any provider re-evaluation pass that was suspended on this operation.
+13. Returns whether a provider response completed successfully.
+
+The composed path created by step 6 determines provider selection for that attempt.
+No stored path is reused.
+
+## Completing a one-time context operation
+
+To complete a one-time context operation with a value, the user agent:
+
+1. Returns if its state is completed or terminated.
+2. Sets its state to completed.
+3. Removes its abort algorithm and removes it from its document's context operations.
+4. Resolves its promise with the value.
+
+Promise reactions therefore run according to ordinary microtask timing, even when the provider responds synchronously during the method call.
+
+## Terminating a context operation
+
+To terminate a context operation, optionally with a reason, the user agent:
+
+1. Returns if its state is completed or terminated.
+2. Sets its state to terminated before running author code.
+3. Removes its abort algorithm and removes it from its document's context operations.
+4. If it has a current provider unsubscribe function, invokes that function and reports any exception.
+5. If it is a one-time operation and a reason was supplied, rejects its promise with that reason.
+
+Setting the state first makes termination idempotent and prevents cleanup from delivering another value during termination.
+
+# Provider announcements and re-evaluation
+
+A provider dispatches a qualifying `ContextProviderEvent` whenever its availability for a context changes.
+On activation it installs its bubbling request listener before dispatching a fresh announcement from the providing element:
 
 ```js
-let providedAlready = false;
-this.dispatchEvent(
-  // Note, this event is not a subscribing event:
-  new ContextRequestEvent(coolThingContext, (coolThing, unsubscribe) => {
-    // Guard against multiple callback calls in case of bad actor providers
-    if (!providedAlready) {
-      this.myCoolThing = coolThing; // do something with value
-    }
-    // `unsubscribe()` should be given if `subscribe` was true on the request 
-    // event. But if a bad provider passed an unsubscribe callback anyway,
-    // you could unsubscribe immediately since we only want it once.
-    unsubscribe?.();
+provider.dispatchEvent(
+  new ContextProviderEvent('context-provider', {
+    context: themeContext,
+    bubbles: true,
+    composed: true,
   })
 );
 ```
 
-It is recommended that custom elements which participate in the Context API should fire their `context-request` events in their `connectedCallback()` method. Likewise in their `disconnectedCallback()` method they should invoke any unsubscribe callbacks they have received.
+The announcement states only that provider availability for a context may have changed.
+It does not assert that the announcing element provides that context or supports subscriptions.
+A provider that cannot fulfill a request leaves it unanswered so another provider can respond.
 
-A more complete example is as follows:
+After dispatching a qualifying provider announcement, the user agent appends a provider re-evaluation pass to the announcing element's node document.
+The pass records the announcing element and context key and snapshots the document's affected pending, active, and dispatching operations with that key in operation order.
+An operation is affected if:
+
+- the announcing element is the operation's current provider; or
+- the announcing element would be on the composed path of a fresh qualifying context request from the operation's target and is not the target itself.
+
+Unless the document is already processing a pass, the user agent processes queued passes before the call to `dispatchEvent()` returns.
+When an operation's turn begins, the user agent skips it if it no longer belongs to that document, is no longer affected, or has completed, terminated, or been aborted.
+If the operation is dispatching, the user agent suspends the pass at that entry until the dispatch finishes instead of re-entering the operation.
+Otherwise, it dispatches the operation and records whether a provider response completed successfully.
+If the operation then no longer belongs to that document or has completed or terminated, the user agent skips the remaining rules for its turn.
+After the operation's re-evaluation turn finishes, the user agent applies any group transfer deferred during that turn before advancing the pass.
+The current-provider case lets a provider that moved, disconnected, or became unavailable release operations it previously fulfilled, even when it is no longer on their request paths.
+
+Re-evaluation occurs even if an announcement listener stops propagation or throws.
+The announcement notifies script; it does not control the user agent's processing.
+
+For an active subscription, a successful response from a different provider transfers the operation under the provider handoff rules in Responding to a request.
+A response from the same provider during user-agent-initiated re-evaluation confirms the existing registration.
+It does not deliver the value again or create another registration, and the provider must supply the same unsubscribe function.
+A repeated request dispatched directly by an author does deliver the current value.
+
+If no provider responds successfully during re-evaluation, an active operation normally remains with its current provider.
+The exception is when the pass's announcing element is that current provider element.
+In that case the announcement means that provider's availability for the context has changed and the lack of a response means it no longer fulfills the operation.
+The user agent records its unsubscribe function, clears the current provider registration, and makes the operation pending before invoking the recorded function and reporting any exception.
+
+The user agent determines the path used by the affected-operation check without dispatching an event or invoking author code, and does not reuse a path from an earlier request.
+Re-dispatch then determines whether the announcing element or another element is the nearest matching provider.
+An announcement from an unrelated branch does not dispatch a request for that operation and has no effect on it.
+
+The user agent does not combine separate announcements.
+An announcement dispatched while a pass is running appends another pass, which starts after earlier queued passes finish.
+An announcement nested inside a context request can return while its pass is suspended on that request.
+The pass resumes after the current request dispatch finishes and before that outer request's `dispatchEvent()` call returns.
+This prevents recursive delivery without losing an announcement or a provider that became reachable after the current event path was created.
+
+# Lifecycle and topology
+
+Each fresh request uses its current composed path to select a provider.
+An ordinary DOM mutation does not change an active operation or trigger re-evaluation by itself.
+
+- Disconnecting a target does not implicitly cancel its operations.
+  A detached tree still has a composed path, and the element can later be reconnected.
+- A custom element normally aborts component-lifetime operations in `disconnectedCallback()` and creates new signals when it reconnects.
+- After a state-preserving move, the component aborts and reissues affected operations from its new position.
+- Moving an ancestor or changing slot assignment can change the nearest provider without directly moving the consumer.
+  Code that performs such a topology change must reissue affected operations or dispatch a provider announcement for each affected context.
+
+When a target element is adopted into another document, the user agent transfers all of its unfinished operations as one ordered group.
+If any operation in that group is being dispatched or re-evaluated, the user agent defers the group transfer until the current dispatch and response steps finish.
+It then collects the operations in their order in the old document and removes them from that document.
+For each active subscription, it records the old provider's unsubscribe function, clears the current provider registration, sets the operation to pending, and invokes the recorded function while reporting any exception.
+After cleanup, it appends each still-unfinished operation to the new node document in the collected relative order.
+It then dispatches each transferred operation once from its new position.
+The user agent does not dispatch an operation in both documents at once.
+
+When an element that is the current provider for operations whose targets remain in the old document is adopted, the user agent re-evaluates those operations in the old document after adoption completes, using the same operation order and non-reentrancy rules as a provider re-evaluation pass.
+Since the adopted provider is no longer on their request paths, another provider can take over or the user agent applies the same transition to pending used when an announcing current provider no longer responds.
+If both a target and its provider are adopted as part of the same subtree, the target-operation transfer rule above takes precedence and the operation is dispatched only in the new document.
+
+When a provider deactivates, it first removes its request listener.
+It then dispatches a qualifying provider announcement for each context it was providing.
+Re-evaluation lets another matching provider take over; otherwise the rule above makes its affected operations pending.
+The user agent invokes their unsubscribe functions during that transition, so no provider registration remains afterward.
+
+Entering the back-forward cache preserves context operations with their document.
+Script is suspended, so no context event is dispatched while the document is frozen.
+Operations resume unchanged when the document is restored.
+
+When a document is discarded rather than cached, the user agent terminates each unfinished context operation.
+It supplies an `AbortError` `DOMException` as the reason when terminating a one-time operation.
+Terminating a subscription invokes its provider's unsubscribe function, if present, without invoking its consumer callback.
+
+# Garbage collection
+
+A document's context-operation set keeps each unfinished operation and its target, callbacks, signal, and promise alive.
+This prevents garbage collection from silently ending a pending promise or subscription.
+
+Authors use `AbortSignal` to bound that lifetime.
+Subscriptions therefore require a signal, and long-lived `requestContext()` calls should normally supply one.
+When an operation completes, terminates, or is aborted, the user agent removes it from the document's context-operation set and releases those references.
+The whole set can be collected after its document is discarded.
+
+# Capability and security model
+
+Context is intentionally an ancestor capability protocol.
+Every listener on a request's composed path can observe its context key, callback, subscription mode, and signal.
+The nearest matching ancestor can respond with any JavaScript value.
+Closed shadow roots do not hide a request from ancestors and are not a security boundary for context.
+Every listener on a provider announcement's composed path can observe its context key and unretargeted `contextTarget`.
+
+An ancestor can also block a request by stopping its propagation without responding.
+This follows ordinary DOM event authority: a component cannot bypass an ancestor that controls its event path.
+
+Unique object and symbol keys prevent accidental collisions and responses from code that never observes a request.
+They do not protect a consumer from an ancestor that can observe and answer that request.
+Components must not request authority from an ancestor they do not trust.
+
+Events and composed paths do not cross document boundaries, so this primitive does not add cross-origin or cross-frame communication.
+Values and callbacks can cross JavaScript realm boundaries within one document under the ordinary DOM event and JavaScript object rules.
+
+The API exposes no persistent device, user, or origin information and requires no permission.
+Its privacy and security properties are those of same-document DOM events and direct JavaScript object exchange.
+
+# Design decisions and alternatives
+
+## Why a native API
+
+The event-only Context Protocol can be, and has been, implemented by libraries.
+Native support is not justified by an inability to provide context in author code.
+It instead provides common entry points and one processing model for components that do not share a library implementation.
+
+The user agent can consistently own pending one-time requests, subscription cancellation, provider handoff, adoption, document teardown, and re-evaluation ordering.
+Without native ownership, each library must provide that retained state and lifecycle behavior, and independently loaded implementations must agree on more than the event shape to coordinate it.
+Direct event dispatch remains available for synchronous discovery and low-level protocol participation.
+
+[Earlier revisions of this proposal](https://github.com/webcomponents-cg/community-protocols/blob/90ddaeb765400d6595a6a18cb63896fdddf5efc3/proposals/context.md) define the event-only protocol, and [`@lit/context`](https://github.com/lit/lit/tree/main/packages/context) is a deployed implementation of that design.
+The native API builds on that experience while making different choices where the user agent needs an atomic response and deterministic operation lifetime.
+
+## Explicit `respond()` rather than callback invocation alone
+
+Calling `respond()` gives the user agent an atomic, testable indication that a provider fulfilled a request.
+Inferring fulfillment from propagation state or from an arbitrary callback invocation would leave the user agent unable to decide whether a late-provider operation should remain pending.
+The callback remains exposed because subscription providers need it for later values.
+It is a user-agent-created wrapper rather than the author callback so later updates can be accepted only from the current provider registration and rejected after handoff or termination.
+Its stable identity gives providers a subscriber key that does not change across redispatch.
+
+## Per-document operation ownership
+
+Composed event paths do not cross document boundaries, so a per-document operation set matches the scope of provider discovery.
+A global or agent-wide coordinator would create cross-document state without adding a provider that a request could reach.
+Requiring authors to install a special context-root object would expose bookkeeping that the user agent can perform consistently itself.
+
+## Exact context events rather than event names alone
+
+Event names are shared author-controlled strings.
+Requiring the context event interface and exact propagation flags prevents an unrelated `CustomEvent` from creating persistent user-agent state.
+It also lets ordinary non-qualifying events continue to use the same names without special dispatch behavior.
+
+## Relationship to earlier protocol implementations
+
+Implementations of the earlier event-only protocol are not retroactively changed by this proposal.
+Their author-created events are non-qualifying events, so the user agent dispatches them normally and does not create or fulfill native context operations.
+Existing consumers and providers using the same earlier protocol therefore continue to interoperate with one another.
+
+Mixed native and event-only implementations do not interoperate automatically.
+An earlier provider fulfills requests by invoking `event.callback(value, unsubscribe)` directly, while a native request requires `event.respond(value, unsubscribe)` to establish the response atomically.
+In the other direction, an earlier request event has no `respond()` method for a native-only provider to call.
+
+A library that supports incremental adoption can implement a dual-mode provider.
+It can feature-detect a callable `respond` member and use it for native requests, while retaining the earlier callback-invocation behavior for other requests.
+Providers must be upgraded or adapted before consumers switch to `requestContext()` or `subscribeContext()`.
+The user agent does not infer a native response from direct callback invocation because it could not then atomically validate the provider, stop competing responses, and install or transfer retained state.
+
+## Stable `contextTarget`
+
+The ordinary event `target` is retargeted across shadow boundaries and therefore does not identify one stable requesting or announcing element to every listener.
+For a request, `contextTarget` supports operation identity, self-response checks, provider bookkeeping, and the consumer callback's `this` value.
+For a provider announcement, it identifies the element whose availability changed.
+Earlier implementations have also used an explicit context target for both event types.
+
+Unlike `target`, `contextTarget` intentionally exposes the original element to ancestors across closed shadow roots.
+That is additional encapsulation-visible information, even though a context request already gives those ancestors authority to observe, answer, or block it.
+The protocol chooses stable participant identity over shadow retargeting because providers may need to associate retained work with the exact consumer or announcing provider.
+Components must not dispatch context requests or provider announcements from an internal element whose identity they are unwilling to reveal to ancestors.
+
+## Promise and subscription methods
+
+A one-time operation that may wait is represented by a Promise.
+Repeated values use a callback plus an `AbortSignal`, while direct event dispatch remains available for consumers that require synchronous one-time delivery or need to participate in the low-level protocol.
+This keeps asynchronous waiting out of the event object itself.
+
+## Optional cancellation for one-time requests
+
+A one-time request may normally be fulfilled during its initial dispatch, so requiring every caller to create an `AbortController` would add ceremony to the common case.
+The signal is therefore optional, and an unanswered request intentionally remains pending for a later provider.
+
+That convenience has a lifetime cost: without a signal, the document retains the pending operation and its target, callback, and promise until it is fulfilled or the document is discarded.
+Authors that cannot accept that lifetime should supply a signal.
+Subscriptions require a signal because they have no successful response that completes the operation automatically.
+
+## Cooperative topology updates
+
+The user agent does not observe every DOM mutation or continuously recompute the nearest provider.
+Doing so would make unrelated tree changes trigger protocol work and author code.
+Instead, code that changes provider availability or relevant topology announces the change or reissues the affected operation.
+
+Until that happens, an active subscription can remain attached to its previous provider even when a fresh request would select another provider.
+This explicit invalidation model keeps observable work scoped to protocol participants and makes re-evaluation timing deterministic.
+
+# Usage
+
+This section is non-normative.
+
+## Requesting one value
 
 ```js
-class SimpleElement extends HTMLElement {
+const themeContext = Symbol('theme');
+
+this.theme = await this.requestContext(themeContext, {
+  signal: this.lifecycleSignal,
+});
+```
+
+## Requesting synchronously with a direct event
+
+```js
+let found = false;
+
+element.dispatchEvent(
+  new ContextRequestEvent('context-request', {
+    context: themeContext,
+    callback: (theme) => {
+      found = true;
+      element.theme = theme;
+    },
+    bubbles: true,
+    composed: true,
+  })
+);
+
+if (!found) {
+  // No provider responded during dispatch.
+}
+```
+
+## Providing one value
+
+```js
+this.addEventListener('context-request', (event) => {
+  if (event.context !== themeContext || event.subscribe) {
+    return;
+  }
+
+  event.respond(this.theme);
+}, { capture: false });
+
+this.dispatchEvent(
+  new ContextProviderEvent('context-provider', {
+    context: themeContext,
+    bubbles: true,
+    composed: true,
+  })
+);
+```
+
+## Subscribing to a value
+
+```js
+const loggerContext = Symbol('logger');
+
+class LoggerConsumer extends HTMLElement {
+  #contextController;
+
   connectedCallback() {
-    this.dispatchEvent(
-      new ContextRequestEvent(
-        loggerContext,
-        (value, unsubscribe) => {
-          // Call the old unsubscribe callback if the unsubscribe call has
-          // changed. This probably means we have a new provider.
-          if (unsubscribe !== this.loggerUnsubscribe) {
-            this.loggerUnsubscribe.?();
-          }
-          this.logger = value;
-          this.loggerUnsubscribe = unsubscribe;
-        },
-        true // we want this event multiple times (if the logger changes)
-      )
+    this.#contextController = new AbortController();
+
+    this.subscribeContext(
+      loggerContext,
+      this.loggerCallback,
+      { signal: this.#contextController.signal }
     );
   }
+
+  loggerCallback(logger) {
+    this.logger = logger;
+  }
+
   disconnectedCallback() {
-    this.loggerUnsubscribe?.();
-    this.loggerUnsubscribe = undefined;
+    this.#contextController.abort();
+    this.#contextController = undefined;
     this.logger = undefined;
   }
 }
 ```
 
-# Open Questions / Previous considerations
-
-## Could we use Promises instead of callbacks?
-
-Many have commented that Promises could be used instead of callback functions. One major drawback of promises is that they cannot be resolved synchronously which would complicate usage of the Context API for simple use-cases.
-
-Another issue with promises is that they do not allow multiple-resolution. Therefore we would not be able to handle cases where a requested value changes over time. This is a capability that we see in the React Context API and believe is valuable for a variety of use cases.
-
-While we could restrict this API to only support a single resolution of a requested value, and then use observable mechanisms on that value to achieve data update behaviors, it is believed that this will complicate simple use-cases unnecessarily.
-
-## Should requesters get to 'accept' providers?
-
-The current API as proposed does not allow a requestor to 'approve' that a provider is going to give it the right object. We have some capability to enforce this in TypeScript, but we could provide a slightly different API that would allow the requesting component to check the value it will receive:
+## Providing a subscription
 
 ```js
-this.dispatchEvent(
-  new ContextRequestEvent(loggerContext, (candidate) => {
-    if (typeof candidate.log === 'function' && typeof candidate.info === 'function') {
-      // we can accept this candidate so return the callback to the provider
-      return (logger, unsubscribe) => {
-        this.logger = logger;
-      };
+this.addEventListener('context-request', (event) => {
+  if (event.context !== loggerContext || !event.subscribe) {
+    return;
+  }
+
+  const callback = event.callback;
+  const existing = this.loggerSubscribers.get(callback);
+
+  if (existing) {
+    event.respond(this.logger, existing);
+
+    return;
+  }
+
+  let active = true;
+
+  const unsubscribe = () => {
+    if (!active) {
+      return;
     }
-  });
-)
+
+    active = false;
+
+    this.loggerSubscribers.delete(callback);
+  };
+
+  this.loggerSubscribers.set(callback, unsubscribe);
+
+  try {
+    event.respond(this.logger, unsubscribe);
+  } catch (error) {
+    unsubscribe();
+
+    throw error;
+  }
+}, { capture: false });
+
+setLogger(logger) {
+  this.logger = logger;
+
+  for (const [callback, unsubscribe] of this.loggerSubscribers) {
+    try {
+      callback(logger, unsubscribe);
+    } catch (error) {
+      reportError(error);
+    }
+  }
+}
 ```
 
-In this alternative, we expect to always synchronously receive a 'candidate' data value that a provider may give us. We can then inspect this candidate value in our component to determine if it has the correct shape, and then return our callback function to accept updates to it.
+## Dispatching a direct subscription request
 
-In this proposal we would likely enforce that the callback always be invoked synchronously.
-
-Alternative APIs could also be explored in this approach, we could for instance have providers append themselves to a list of potential providers along with candidate value objects, and then allow our components to pick which provider they wish to use:
+Direct event dispatch exposes synchronous initial delivery while retaining the subscription for later updates:
 
 ```js
-const contextRequest = new ContextRequestEvent(loggerContext);
-this.dispatchEvent(context);
-if (!contextRequest.providers) {
-  // no providers for logger
-  return;
-}
-const provider = contextRequest.providers.find((loggerProvider) => {
-  // test if the provider is the type we want or the value it provides is right
+const controller = new AbortController();
+
+const request = new ContextRequestEvent('context-request', {
+  context: loggerContext,
+  callback(logger) {
+    console.assert(this === consumer);
+    consumer.logger = logger;
+  },
+  subscribe: true,
+  signal: controller.signal,
+  bubbles: true,
+  composed: true,
 });
-const unsubscribe = provider.provide(this, (logger) => {
-  this.logger = logger;
-});
-// later...
-unsubscribe(); // don't need updates anymore
+
+consumer.dispatchEvent(request);
+
+// Ask the current provider to deliver its value again without creating a
+// second subscription.
+consumer.dispatchEvent(request);
+
+controller.abort();
 ```
 
-These alternatives do provide more capability, but it's an open question as to whether or not this complexity is warranted or desired. It also opens up a larger question about what would the candidate value be? Would it have to be an object of the requested type, could it be some other protocol to determine uniformity between the requested data and the actual data? This begins to seem more complex than we really need here for unnecessary type safety overhead. It is suggested if consumers want type safety then they should use TypeScript to achieve this.
+The request is bound to `consumer` by its first qualifying dispatch.
+Dispatching it from another element throws an `InvalidStateError` `DOMException`.
 
-# Definitions
+## TypeScript integration
 
-Below are some TypeScript definitions for the common parts of the proposed protocol:
+Web IDL defines the native API surface and does not express a relationship between a context key and its value type.
+A TypeScript library can add that static relationship with branded keys and typed wrappers:
 
-```typescript
-/**
- * A context key.
- *
- * A context key can be any type of object, including strings and symbols. The
- *  Context type brands the key type with the `__context__` property that
- * carries the type of the value the context references.
- */
-export type Context<KeyType, ValueType> = KeyType & {__context__: ValueType};
+```ts
+declare const contextValueType: unique symbol;
 
-/**
- * An unknown context type
- */
-export type UnknownContext = Context<unknown, unknown>;
+type Context<T> = symbol & {
+  readonly [contextValueType]: T;
+};
 
-/**
- * A helper type which can extract a Context value type from a Context type
- */
-export type ContextType<T extends UnknownContext> =
-  T extends Context<infer _, infer V> ? V : never;
-
-/**
- * A function which creates a Context value object
- */
-export const createContext = <ValueType>(key: unknown) =>
-  key as Context<typeof key, ValueType>;
-
-/**
- * A callback which is provided by a context requester and is called with the value satisfying the request.
- * This callback can be called multiple times by context providers as the requested value is changed.
- */
-export type ContextCallback<ValueType> = (
-  value: ValueType,
-  unsubscribe?: () => void
-) => void;
-
-/**
- * An event fired by a context requester to signal it desires a named context.
- *
- * A provider should inspect the `context` property of the event to determine if it has a value that can
- * satisfy the request, calling the `callback` with the requested value if so.
- *
- * If the requested context event contains a truthy `subscribe` value, then a provider can call the callback
- * multiple times if the value is changed, if this is the case the provider should pass an `unsubscribe`
- * function to the callback which requesters can invoke to indicate they no longer wish to receive these updates.
- */
-export class ContextRequestEvent<T extends UnknownContext> extends Event {
-  public constructor(
-    public readonly context: T,
-    public readonly callback: ContextCallback<ContextType<T>>,
-    public readonly subscribe?: boolean
-  ) {
-    super('context-request', {bubbles: true, composed: true});
-  }
+function createContext<T>(description: string): Context<T> {
+  return Symbol(description) as Context<T>;
 }
 
-declare global {
-  interface HTMLElementEventMap {
-    /**
-     * A 'context-request' event can be emitted by any element which desires
-     * a context value to be injected by an external provider.
-     */
-    'context-request': ContextRequestEvent<Context<unknown, unknown>>;
-  }
+function requestTypedContext<T>(
+  element: Element,
+  context: Context<T>,
+  options: {signal?: AbortSignal} = {},
+): Promise<T> {
+  return element.requestContext(context, options) as Promise<T>;
 }
+
+function subscribeTypedContext<T>(
+  element: Element,
+  context: Context<T>,
+  callback: (value: T) => void,
+  options: {signal: AbortSignal},
+): void {
+  element.subscribeContext(context, callback, options);
+}
+
+interface Logger {
+  log(message: string): void;
+}
+
+declare const consumer: Element;
+declare const lifecycleSignal: AbortSignal;
+
+const loggerContext = createContext<Logger>('logger');
+const logger = await requestTypedContext(consumer, loggerContext, {
+  signal: lifecycleSignal,
+});
+
+logger.log('Context received');
+
+subscribeTypedContext(
+  consumer,
+  loggerContext,
+  (updatedLogger) => updatedLogger.log('Context updated'),
+  {signal: lifecycleSignal},
+);
 ```
 
-# Changes
+These helpers provide compile-time checking only.
+They do not validate a provider's value at runtime or change the native methods' Web IDL signatures.
 
-- 2025-05-02: Added changelog to track changes.
-- 2025-05-02: Changed `stopPropagation` to `stopImmediatePropagation`.
-- 2024-10-17: Added a provider recommendation to safeguard against memory leaks.
-- 2024-06-27: Cleaned up proposal overview.
-- 2024-04-09: Fixed type inconsistencies.
-- 2023-11-04: Moved proposal to candidate status.
-- 2023-04-13: Fixed typos.
-- 2023-02-03: Renamed `multiple` to `subscribe`.
-- 2023-02-03: Updated context object interface description to allow any type as a context.
-- 2022-05-20: Fixed typos.
-- 2022-04-21: Clarified ordering of `stopPropagation` / `callback`.
-- 2021-11-22: Fixed typos.
-- 2021-09-01: Cleaned up proposal overview.
-- 2021-07-02: Initial draft.
+# Processing-model summary
+
+The observable behavior above requires user-agent state for:
+
+- the response status of each `ContextRequestEvent` dispatch;
+- each document's ordered context-operation set and provider re-evaluation queue;
+- abort algorithms and current provider cleanup for active subscriptions; and
+- adoption, document teardown, and garbage-collection integration.
+
+The protocol does not observe every DOM mutation or cache a composed path.
+Provider matching always uses ordinary event dispatch.
+How a user agent indexes operations is not observable, provided key comparison remains strict equality and the specified ordering is preserved.
+
+# Proposed web-platform test coverage
+
+The corresponding web-platform tests should cover at least:
+
+- WebIDL exposure, constructor defaults, and invalid `NaN` keys;
+- qualifying and non-qualifying event combinations, including legacy-shaped author events that remain ordinary events;
+- `contextTarget` initialization, stability, same-target redispatch, rejection of different-target redispatch, shadow retargeting, and original-target exposure across closed roots;
+- rejection of responses from capturing listeners, the request target, duplicate providers, and late calls, plus acceptance from a non-capturing shadow-host listener whose `eventPhase` is `AT_TARGET`;
+- synchronous response and asynchronous Promise reaction ordering;
+- one-time immediate, pending, abort-before-dispatch, abort-during-dispatch without state resurrection, direct-event signal behavior, thenable, and late-provider fulfillment;
+- method-based and direct subscriptions, required and already-aborted signals, updates, callback `this` values, idempotency, and terminal-event redispatch;
+- initial and later callback exceptions, non-propagation of reported consumer exceptions, and cleanup exceptions;
+- nested open and closed shadow roots, slots, and nearest-provider selection;
+- provider activation, replacement, deactivation, failed transfer, and failed replacement during current-provider deactivation;
+- unrelated announcements that dispatch no requests, operation-order processing including reentrant operation creation, and announcements dispatched during initial dispatch or re-evaluation;
+- disconnect, reconnect, state-preserving moves, slot changes, adoption cleanup, and transferred-operation ordering;
+- same-origin and cross-origin iframe boundaries;
+- back-forward cache restoration and document teardown; and
+- garbage-collection tests using weak references where the harness supports deterministic collection.
+
+State-machine tests should also cover sequences that combine dispatch, response, abort, announcement, move, adoption, and teardown rather than testing those operations only in isolation.

--- a/proposals/context.md
+++ b/proposals/context.md
@@ -4,7 +4,7 @@ An open protocol for passing contextual data between components.
 
 Author: Benjamin Delarre
 
-Document status: Candidate
+Document status: Draft
 
 Last update: 2026-08-13
 


### PR DESCRIPTION
This PR revises the **Context Protocol proposal** to clarify its behavior and define a complete lifecycle for operations previously left to individual libraries:

- Provider lookup still follows the composed DOM event path, but the nearest matching provider now responds explicitly using `event.respond()`.
- Consumers can await one value with `element.requestContext()`, which returns a promise that remains pending if no provider is yet available.
- Consumers can receive ongoing updates with `element.subscribeContext()` until its signal is aborted.
- The browser manages the operation lifecycle, including pending requests, cancellation, announced provider changes, subscription handoff, document adoption, and teardown.

The result preserves the protocol’s decentralized, shadow-DOM-friendly provider model while giving authors a simpler consumer API and implementations a consistent, testable lifecycle.

#### Example: Direct dispatch

A consumer dispatches a context request, and the nearest matching provider responds along the event path:

```js
const themeContext = Symbol('theme');
const provider = document.querySelector('theme-provider');
const consumer = provider.querySelector('profile-card');

provider.addEventListener('context-request', (event) => {
  if (event.context === themeContext) {
    event.respond(defaultTheme);
  }
});

consumer.dispatchEvent(
  new ContextRequestEvent('context-request', {
    context: themeContext,
    callback(theme) {
      consumer.theme = theme;
    },
    bubbles: true,
    composed: true,
  })
);
```
> This preserves synchronous, event-based lookup while giving providers an explicit response contract instead of requiring them to invoke a consumer callback directly.

#### Example: Awaiting one value

A component can request a value from its nearest matching provider. If no provider is currently available, the promise remains pending until one responds:

```js
const themeContext = Symbol('theme');
const profileCard = document.querySelector('profile-card');

const theme = await profileCard.requestContext(themeContext);
```
> This fills the “no provider yet” gap: a one-time request can remain pending and resolve when a matching provider later becomes available.

#### Example: Receiving updates

A consumer can subscribe to values:

```js
const themeContext = Symbol('theme');
const profileCard = document.querySelector('profile-card');
const controller = new AbortController();

profileCard.subscribeContext(
  themeContext,
  (theme) => {
    profileCard.theme = theme;
  },
  { signal: controller.signal }
);

// ... at some point later stop receiving updates.
controller.abort();
```
> This standardizes subscription lifetime and cancellation, while allowing the browser to manage provider replacement and unsubscribe handoff.

## Feedback requested

If this direction is appropriate, I would appreciate feedback on:
- consumer methods versus provider events as the API boundary;
- `contextTarget` and lookup across shadow boundaries;
- cancellation and subscription lifetimes; and
- migration for existing event-only implementations.

## How to read this

This is a near-complete rewrite, so please read the [rendered proposal](https://github.com/jonathantneal/community-protocols/blob/jon/context-protocol-finalization/proposals/context.md) rather than the raw diff.

The opening API overview and [Usage](https://github.com/jonathantneal/community-protocols/blob/jon/context-protocol-finalization/proposals/context.md#usage) examples provide the quickest introduction. The detailed processing model, rationale, and proposed web-platform test coverage follow.

## Compatibility

Existing event-only consumers and providers continue interoperating with one another unchanged. Mixed native and event-only participants require the documented dual-mode provider path, which feature-detects `respond()`.
